### PR TITLE
Add EJS views for SSR templates

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -11,6 +11,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
+// View engine (EJS) for optional server-side rendering
+app.set("views", path.join(__dirname, "..", "views"));
+app.set("view engine", "ejs");
 
 // --- Config ---
 const PORT = process.env.PORT || 3000;
@@ -131,9 +134,13 @@ app.get(
 );
 
 // (optional) SSR route placeholder if you want server-side cards later
-// app.get("/", (req, res) => {
-//   res.render("index.ejs", { /* preloaded data here */ });
-// });
+app.get("/", (req, res) => {
+  res.render("index", {
+    title: "Timezone Dashboard",
+    content: "",
+    data: {},
+  });
+});
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT} (${NODE_ENV})`);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title><%= title %></title>
+</head>
+<body>
+  <div id="app"><%- content %></div>
+  <script>
+    window.__INITIAL_DATA__ = <%- JSON.stringify(data || {}) %>;
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add EJS view engine config and route in Express server
- add base `index.ejs` template for server-side rendering

## Testing
- `node server/server.js` *(fails: Cannot find package 'express')*


------
https://chatgpt.com/codex/tasks/task_e_689d35639b58833184eecb64d622b7ad